### PR TITLE
Circuit oram/dependency inject evictor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,8 @@ dependencies = [
 name = "test-helper"
 version = "2.0.0"
 dependencies = [
+ "aligned-array",
+ "aligned-cmov",
  "rand_core",
  "rand_hc",
 ]

--- a/mc-oblivious-map/Cargo.toml
+++ b/mc-oblivious-map/Cargo.toml
@@ -26,7 +26,7 @@ siphasher = "0.3"
 mc-oblivious-ram = { path = "../mc-oblivious-ram" }
 test-helper = { path = "../test-helper" }
 
-criterion = "0.3"
+criterion = {version = "0.3", features = ["html_reports"]}
 
 # This is only needed by benchmarks... we should really put this on crates.io
 mc-crypto-rand = { git = "https://github.com/mobilecoinfoundation/mobilecoin", rev = "9653694d5fcd8fb9438728547467518b634d6cf5" }

--- a/mc-oblivious-map/benches/ingest.rs
+++ b/mc-oblivious-map/benches/ingest.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use aligned_cmov::{typenum, A8Bytes, ArrayLength};
+use aligned_cmov::{typenum, A8Bytes};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mc_crypto_rand::McRng;
 use mc_oblivious_map::{CuckooHashTable, CuckooHashTableCreator};
 use mc_oblivious_ram::PathORAM4096Z4Creator;
 use mc_oblivious_traits::{HeapORAMStorageCreator, OMapCreator, ORAMCreator, ObliviousHashMap};
 use std::time::Duration;
+use test_helper::a8_8;
 use typenum::{U1024, U32};
 
 type ORAMCreatorZ4 = PathORAM4096Z4Creator<McRng, HeapORAMStorageCreator>;
@@ -16,16 +17,6 @@ type CuckooCreatorZ4 = CuckooHashTableCreator<U1024, McRng, ORAMCreatorZ4>;
 
 fn make_omap(capacity: u64) -> Table {
     CuckooCreatorZ4::create(capacity, 32, || McRng {})
-}
-
-/// Make a8-bytes that are initialized to a particular byte value
-/// This makes tests shorter to write
-fn a8_8<N: ArrayLength<u8>>(src: u8) -> A8Bytes<N> {
-    let mut result = A8Bytes::<N>::default();
-    for byte in result.as_mut_slice() {
-        *byte = src;
-    }
-    result
 }
 
 pub fn path_oram_4096_z4_1mil_ingest_write(c: &mut Criterion) {

--- a/mc-oblivious-map/benches/view.rs
+++ b/mc-oblivious-map/benches/view.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use aligned_cmov::{typenum, A8Bytes, ArrayLength};
+use aligned_cmov::{typenum, A8Bytes};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mc_crypto_rand::McRng;
 use mc_oblivious_map::{CuckooHashTable, CuckooHashTableCreator};
 use mc_oblivious_ram::PathORAM4096Z4Creator;
 use mc_oblivious_traits::{HeapORAMStorageCreator, OMapCreator, ORAMCreator, ObliviousHashMap};
 use std::time::Duration;
+use test_helper::a8_8;
 use typenum::{U1024, U16, U240};
 
 type ORAMCreatorZ4 = PathORAM4096Z4Creator<McRng, HeapORAMStorageCreator>;
@@ -16,16 +17,6 @@ type CuckooCreatorZ4 = CuckooHashTableCreator<U1024, McRng, ORAMCreatorZ4>;
 
 fn make_omap(capacity: u64) -> Table {
     CuckooCreatorZ4::create(capacity, 32, || McRng {})
-}
-
-/// Make a8-bytes that are initialized to a particular byte value
-/// This makes tests shorter to write
-fn a8_8<N: ArrayLength<u8>>(src: u8) -> A8Bytes<N> {
-    let mut result = A8Bytes::<N>::default();
-    for byte in result.as_mut_slice() {
-        *byte = src;
-    }
-    result
 }
 
 pub fn path_oram_4096_z4_1mil_view_write(c: &mut Criterion) {

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -4,28 +4,12 @@
 //! for tree based orams which include path oram and circuit oram. These
 //! strategies will be used for evicting stash elements to the tree oram.
 
-use aligned_cmov::A8Bytes;
-
-use aligned_cmov::A64Bytes;
-
-use aligned_cmov::typenum::Prod;
-use balanced_tree_index::TreeIndex;
-
-use core::ops::Mul;
-
-use aligned_cmov::typenum::Unsigned;
-
-use aligned_cmov::typenum::U64;
-
-use aligned_cmov::typenum::U8;
-
-use aligned_cmov::typenum::PartialDiv;
-
-use aligned_cmov::ArrayLength;
-
-use rand_core::CryptoRng;
-
 use crate::path_oram::{BranchCheckout, MetaSize};
+use aligned_cmov::{
+    typenum::{PartialDiv, Prod, Unsigned, U64, U8},
+    A64Bytes, A8Bytes, ArrayLength,
+};
+use core::ops::Mul;
 use rand_core::RngCore;
 
 /// Selects branches in reverse lexicographic order. Num_bits_needed corresponds

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -28,6 +28,9 @@ use rand_core::CryptoRng;
 use crate::path_oram::{BranchCheckout, MetaSize};
 use rand_core::RngCore;
 
+/// Selects branches in reverse lexicographic order. Num_bits_needed corresponds
+/// to the number of possible branches that need to be explored. The iteration i
+/// corresponds to the ith branch in reverse lexicographic order.
 fn deterministic_get_next_branch_to_evict(num_bits_needed: u32, iteration: u64) -> u64 {
     // Return 1 if the number of bits needed is 0. This is to shortcut the
     // calculation furtherdown that would overflow, and does not leak
@@ -36,6 +39,8 @@ fn deterministic_get_next_branch_to_evict(num_bits_needed: u32, iteration: u64) 
     if num_bits_needed == 0 {
         return 1;
     }
+    // This is the first index at which leafs exist, the most significant digit
+    // of all leafs is 1.
     let leaf_significant_index: u64 = 1 << (num_bits_needed);
     let test_position: u64 =
         ((iteration).reverse_bits() >> (64 - num_bits_needed)) % leaf_significant_index;

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -42,7 +42,7 @@ fn deterministic_get_next_branch_to_evict(num_bits_to_be_reversed: u32, iteratio
 
 /// An evictor that implements a random branch selection and the path oram
 /// eviction strategy
-pub struct PathOramRandomEvict<RngType>
+pub struct PathOramRandomEvictor<RngType>
 where
     RngType: RngCore + CryptoRng + Send + Sync + 'static,
 {
@@ -52,7 +52,7 @@ where
     tree_height: u32,
 }
 
-impl<RngType> BranchSelector for PathOramRandomEvict<RngType>
+impl<RngType> BranchSelector for PathOramRandomEvictor<RngType>
 where
     RngType: RngCore + CryptoRng + Send + Sync + 'static,
 {
@@ -65,7 +65,7 @@ where
         self.number_of_additional_branches_to_evict
     }
 }
-impl<ValueSize, Z, RngType> EvictionStrategy<ValueSize, Z> for PathOramRandomEvict<RngType>
+impl<ValueSize, Z, RngType> EvictionStrategy<ValueSize, Z> for PathOramRandomEvictor<RngType>
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
@@ -87,13 +87,13 @@ where
 
 /// An evictor that implements a deterministic branch selection in reverse
 /// lexicographic order and using the path oram eviction strategy
-pub struct PathOramDeterministicEvict {
+pub struct PathOramDeterministicEvictor {
     number_of_additional_branches_to_evict: usize,
     branches_evicted: u64,
     tree_height: u32,
     tree_breadth: u64,
 }
-impl PathOramDeterministicEvict {
+impl PathOramDeterministicEvictor {
     /// Create a new deterministic branch selector that will select
     /// num_elements_to_evict branches per access
     /// tree height: corresponds to the height of tree
@@ -110,7 +110,7 @@ impl PathOramDeterministicEvict {
     }
 }
 
-impl BranchSelector for PathOramDeterministicEvict {
+impl BranchSelector for PathOramDeterministicEvictor {
     fn get_next_branch_to_evict(&mut self) -> u64 {
         //The height of the root is 0, so the number of bits needed for the leaves is
         // just the height
@@ -123,7 +123,7 @@ impl BranchSelector for PathOramDeterministicEvict {
         self.number_of_additional_branches_to_evict
     }
 }
-impl<ValueSize, Z> EvictionStrategy<ValueSize, Z> for PathOramDeterministicEvict
+impl<ValueSize, Z> EvictionStrategy<ValueSize, Z> for PathOramDeterministicEvictor
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
@@ -227,10 +227,10 @@ where
     Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
     Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
 {
-    type Output = PathOramDeterministicEvict;
+    type Output = PathOramDeterministicEvictor;
 
     fn create(&self, height: u32) -> Self::Output {
-        PathOramDeterministicEvict::new(self.number_of_additional_branches_to_evict, height)
+        PathOramDeterministicEvictor::new(self.number_of_additional_branches_to_evict, height)
     }
 }
 

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -15,14 +15,20 @@ use balanced_tree_index::TreeIndex;
 use core::ops::Mul;
 use rand_core::{CryptoRng, RngCore};
 
-/// Selects branches in reverse lexicographic order. Num_bits_needed corresponds
-/// to the number of possible branches that need to be explored. The iteration i
-/// corresponds to the ith branch in reverse lexicographic order.
+/// Selects branches in reverse lexicographic order, where the most significant
+/// digit of the branch is always 1, corresponding to the leaf node that
+/// represents that branch.
+/// E.g. for a depth of 3:
+/// 100, 110, 101, 111
+/// num_bits_needed corresponds to the number of possible branches that need to
+/// be explored, and is 1 less than the number of bits in the leaf node.
+/// The iteration i corresponds to the ith branch in reverse lexicographic
+/// order.
+/// 
 fn deterministic_get_next_branch_to_evict(num_bits_needed: u32, iteration: u64) -> u64 {
-    // Return 1 if the number of bits needed is 0. This is to shortcut the
-    // calculation furtherdown that would overflow, and does not leak
-    // information because the number of bits is structural information rather
-    // than query specific.
+    // Return 1 if the number of bits needed is 0. Calculation furtherdown would
+    // overflow, and shortcutting here does not leak information because the
+    // number of bits is structural information rather than query specific.
     if num_bits_needed == 0 {
         return 1;
     }

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -9,6 +9,7 @@ use aligned_cmov::A8Bytes;
 use aligned_cmov::A64Bytes;
 
 use aligned_cmov::typenum::Prod;
+use balanced_tree_index::TreeIndex;
 
 use core::ops::Mul;
 
@@ -22,11 +23,169 @@ use aligned_cmov::typenum::PartialDiv;
 
 use aligned_cmov::ArrayLength;
 
+use rand_core::CryptoRng;
+
 use crate::path_oram::{BranchCheckout, MetaSize};
+use rand_core::RngCore;
+
+fn deterministic_get_next_branch_to_evict(num_bits_needed: u32, iteration: u64) -> u64 {
+    let leaf_significant_index: u64 = 1 << (num_bits_needed);
+    let test_position: u64 =
+        ((iteration).reverse_bits() >> (64 - num_bits_needed)) % leaf_significant_index;
+    leaf_significant_index + test_position
+}
+
+/// An evictor that implements a random branch selection and the path oram
+/// eviction strategy
+pub struct PathOramRandomEvict<RngType>
+where
+    RngType: RngCore + CryptoRng + Send + Sync + 'static,
+{
+    rng: RngType,
+    number_of_additional_branches_to_evict: usize,
+    branches_evicted: u64,
+    tree_height: u32,
+}
+#[allow(dead_code)]
+impl<RngType> PathOramRandomEvict<RngType>
+where
+    RngType: RngCore + CryptoRng + Send + Sync + 'static,
+{
+    /// Create a new deterministic branch selector that will select
+    /// num_elements_to_evict branches per access
+    pub fn new(
+        number_of_additional_branches_to_evict: usize,
+        tree_height: u32,
+        rng: RngType,
+    ) -> Self {
+        Self {
+            rng,
+            number_of_additional_branches_to_evict,
+            tree_height,
+            branches_evicted: 0,
+        }
+    }
+}
+
+impl<RngType> BranchSelector for PathOramRandomEvict<RngType>
+where
+    RngType: RngCore + CryptoRng + Send + Sync + 'static,
+{
+    fn get_next_branch_to_evict(&mut self) -> u64 {
+        self.branches_evicted += 1;
+        1u64.random_child_at_height(self.tree_height, &mut self.rng)
+    }
+
+    fn get_number_of_additional_branches_to_evict(&self) -> usize {
+        self.number_of_additional_branches_to_evict
+    }
+}
+impl<ValueSize, Z, RngType> EvictionStrategy<ValueSize, Z> for PathOramRandomEvict<RngType>
+where
+    ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
+    Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
+    Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
+    Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
+    RngType: RngCore + CryptoRng + Send + Sync + 'static,
+{
+    fn evict_from_stash_to_branch(
+        &self,
+        stash_data: &mut [A64Bytes<ValueSize>],
+        stash_meta: &mut [A8Bytes<MetaSize>],
+        branch: &mut BranchCheckout<ValueSize, Z>,
+    ) {
+        path_oram_eviction_strategy::<ValueSize, Z>(stash_data, stash_meta, branch);
+    }
+}
+
+/// An evictor that implements a deterministc branch selection and the path
+/// oram eviction strategy
+pub struct PathOramDeterministicEvict {
+    number_of_additional_branches_to_evict: usize,
+    branches_evicted: u64,
+    tree_height: u32,
+    tree_size: u64,
+}
+impl PathOramDeterministicEvict {
+    /// Create a new deterministic branch selector that will select
+    /// num_elements_to_evict branches per access
+    pub fn new(
+        number_of_additional_branches_to_evict: usize,
+        tree_height: u32,
+        tree_size: u64,
+    ) -> Self {
+        Self {
+            number_of_additional_branches_to_evict,
+            tree_height,
+            tree_size,
+            branches_evicted: 0,
+        }
+    }
+}
+
+impl BranchSelector for PathOramDeterministicEvict {
+    fn get_next_branch_to_evict(&mut self) -> u64 {
+        //The height of the root is 0, so the number of bits needed for the leaves is
+        // just the height
+        let iteration = self.branches_evicted;
+        self.branches_evicted = (self.branches_evicted + 1) % self.tree_size;
+        deterministic_get_next_branch_to_evict(self.tree_height, iteration)
+    }
+
+    fn get_number_of_additional_branches_to_evict(&self) -> usize {
+        self.number_of_additional_branches_to_evict
+    }
+}
+impl<ValueSize, Z> EvictionStrategy<ValueSize, Z> for PathOramDeterministicEvict
+where
+    ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
+    Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
+    Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
+    Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
+{
+    fn evict_from_stash_to_branch(
+        &self,
+        stash_data: &mut [A64Bytes<ValueSize>],
+        stash_meta: &mut [A8Bytes<MetaSize>],
+        branch: &mut BranchCheckout<ValueSize, Z>,
+    ) {
+        path_oram_eviction_strategy::<ValueSize, Z>(stash_data, stash_meta, branch);
+    }
+}
+
+/// Eviction algorithm defined in path oram. Packs the branch and greedily
+/// tries to evict everything from the stash into the checked out branch
+fn path_oram_eviction_strategy<ValueSize, Z>(
+    stash_data: &mut [A64Bytes<ValueSize>],
+    stash_meta: &mut [A8Bytes<MetaSize>],
+    branch: &mut BranchCheckout<ValueSize, Z>,
+) where
+    ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
+    Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
+    Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
+    Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
+{
+    branch.pack();
+    //Greedily place elements of the stash into the branch as close to the leaf as
+    // they can go.
+    for idx in 0..stash_data.len() {
+        branch.ct_insert(1.into(), &stash_data[idx], &mut stash_meta[idx]);
+    }
+}
+
+pub trait BranchSelector {
+    /// Returns the leaf index of the next branch to call evict from stash
+    /// to branch on.
+    fn get_next_branch_to_evict(&mut self) -> u64;
+
+    /// Returns the number of branches to call evict from stash to branch
+    /// on.
+    fn get_number_of_additional_branches_to_evict(&self) -> usize;
+}
 
 /// Evictor trait conceptually is a mechanism for moving stash elements into
 /// the oram.
-pub trait Evictor<ValueSize, Z>
+pub trait EvictionStrategy<ValueSize, Z>
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
@@ -42,30 +201,72 @@ where
         branch: &mut BranchCheckout<ValueSize, Z>,
     );
 }
-pub struct PathOramEvict {}
-impl<ValueSize, Z> Evictor<ValueSize, Z> for PathOramEvict
+
+/// A factory which creates an Evictor
+pub trait EvictorCreator<ValueSize, Z>
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
     Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
     Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
 {
-    fn evict_from_stash_to_branch(
-        &self,
-        stash_data: &mut [A64Bytes<ValueSize>],
-        stash_meta: &mut [A8Bytes<MetaSize>],
-        branch: &mut BranchCheckout<ValueSize, Z>,
-    ) {
-        branch.pack();
-        //Greedily place elements of the stash into the branch as close to the leaf as
-        // they can go.
-        for idx in 0..stash_data.len() {
-            branch.ct_insert(1.into(), &stash_data[idx], &mut stash_meta[idx]);
+    type Output: EvictionStrategy<ValueSize, Z> + BranchSelector + Send + Sync + 'static;
+
+    fn create(&self, size: u64, height: u32) -> Self::Output;
+}
+
+/// A factory which creates an PathOramDeterministicEvictor that evicts an
+/// additional number_of_additional_branches_to_evict
+pub struct PathOramDeterministicEvictCreator {
+    number_of_additional_branches_to_evict: usize,
+}
+impl PathOramDeterministicEvictCreator {
+    /// Create a factory for a deterministic branch selector that will evict
+    /// number_of_additional_branches_to_evict branches per access
+    pub fn new(number_of_additional_branches_to_evict: usize) -> Self {
+        Self {
+            number_of_additional_branches_to_evict,
         }
     }
 }
-impl PathOramEvict {
-    pub fn new() -> Self {
-        Self {}
+
+impl<ValueSize, Z> EvictorCreator<ValueSize, Z> for PathOramDeterministicEvictCreator
+where
+    ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
+    Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
+    Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
+    Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
+{
+    type Output = PathOramDeterministicEvict;
+
+    fn create(&self, size: u64, height: u32) -> Self::Output {
+        PathOramDeterministicEvict::new(self.number_of_additional_branches_to_evict, height, size)
+    }
+}
+
+#[cfg(test)]
+mod internal_tests {
+    use super::*;
+    #[test]
+    // Check that deterministic oram correctly chooses leaf values
+    fn test_deterministic_oram_get_branches_to_evict() {
+        let test_branch = deterministic_get_next_branch_to_evict(3, 0);
+        assert_eq!(test_branch, 8);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 1);
+        assert_eq!(test_branch, 12);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 2);
+        assert_eq!(test_branch, 10);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 3);
+        assert_eq!(test_branch, 14);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 4);
+        assert_eq!(test_branch, 9);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 5);
+        assert_eq!(test_branch, 13);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 6);
+        assert_eq!(test_branch, 11);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 7);
+        assert_eq!(test_branch, 15);
+        let test_branch = deterministic_get_next_branch_to_evict(3, 8);
+        assert_eq!(test_branch, 8);
     }
 }

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -94,8 +94,9 @@ pub struct PathOramDeterministicEvictor {
 }
 impl PathOramDeterministicEvictor {
     /// Create a new deterministic branch selector that will select
-    /// num_elements_to_evict branches per access
-    /// tree height: corresponds to the height of tree
+    /// `number_of_additional_branches_to_evict`: branches per access in
+    /// excess of branch with accessed element.
+    /// `tree height`: corresponds to the height of tree
     pub fn new(number_of_additional_branches_to_evict: usize, tree_height: u32) -> Self {
         Self {
             number_of_additional_branches_to_evict,
@@ -196,7 +197,7 @@ where
     type Output: EvictionStrategy<ValueSize, Z> + BranchSelector + Send + Sync + 'static;
 
     /// Creates an eviction strategy
-    /// height: height of the tree eviction will be called on, impacts branch
+    /// `height`: height of the tree eviction will be called on, impacts branch
     /// selection.
     fn create(&self, height: u32) -> Self::Output;
 }

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -213,7 +213,7 @@ pub struct PathOramDeterministicEvictorCreator {
 }
 impl PathOramDeterministicEvictorCreator {
     /// Create a factory for a deterministic branch selector that will evict
-    /// number_of_additional_branches_to_evict branches per access
+    /// `number_of_additional_branches_to_evict` branches per access
     pub fn new(number_of_additional_branches_to_evict: usize) -> Self {
         Self {
             number_of_additional_branches_to_evict,

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -86,8 +86,7 @@ where
 }
 
 /// An evictor that implements a deterministic branch selection in reverse
-/// lexicographic order and the path
-/// oram eviction strategy
+/// lexicographic order and using the path oram eviction strategy
 pub struct PathOramDeterministicEvict {
     number_of_additional_branches_to_evict: usize,
     branches_evicted: u64,
@@ -97,6 +96,9 @@ pub struct PathOramDeterministicEvict {
 impl PathOramDeterministicEvict {
     /// Create a new deterministic branch selector that will select
     /// num_elements_to_evict branches per access
+    /// tree height: corresponds to the height of tree
+    /// tree_size: corresponds to the number of elements that can be stored in
+    /// the tree (normal size of the tree*bucket size)
     pub fn new(
         number_of_additional_branches_to_evict: usize,
         tree_height: u32,

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -161,12 +161,13 @@ fn path_oram_eviction_strategy<ValueSize, Z>(
 }
 
 pub trait BranchSelector {
-    /// Returns the leaf index of the next branch to call evict from stash
-    /// to branch on.
+    /// Returns the leaf index of the next branch to call 
+    /// [EvictionStrategy::evict_from_stash_to_branch] on.
     fn get_next_branch_to_evict(&mut self) -> u64;
 
-    /// Returns the number of branches to call evict from stash to branch
-    /// on.
+    /// Returns the number of branches to call 
+    /// [EvictionStrategy::evict_from_stash_to_branch] on.
+
     fn get_number_of_additional_branches_to_evict(&self) -> usize;
 }
 

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -9,8 +9,9 @@ use aligned_cmov::{
     typenum::{PartialDiv, Prod, Unsigned, U64, U8},
     A64Bytes, A8Bytes, ArrayLength,
 };
+use balanced_tree_index::TreeIndex;
 use core::ops::Mul;
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 
 /// Selects branches in reverse lexicographic order. Num_bits_needed corresponds
 /// to the number of possible branches that need to be explored. The iteration i

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -17,14 +17,13 @@ use rand_core::{CryptoRng, RngCore};
 
 /// Selects branches in reverse lexicographic order, where the most significant
 /// digit of the branch is always 1, corresponding to the leaf node that
-/// represents that branch. Reverse lexicographic ordering only on the `num_bits_to_be_reversed`
-/// E.g. for a depth of 3:
+/// represents that branch. Reverse lexicographic ordering only on the
+/// `num_bits_to_be_reversed` E.g. for a depth of 3:
 /// 100, 110, 101, 111
-/// `num_bits_to_be_reversed` corresponds to the number of possible branches that need to
-/// be explored, and is 1 less than the number of bits in the leaf node.
-/// The iteration i corresponds to the ith branch in reverse lexicographic
+/// `num_bits_to_be_reversed` corresponds to the number of possible branches
+/// that need to be explored, and is 1 less than the number of bits in the leaf
+/// node. `iteration` i corresponds to the ith branch in reverse lexicographic
 /// order.
-/// 
 fn deterministic_get_next_branch_to_evict(num_bits_to_be_reversed: u32, iteration: u64) -> u64 {
     // Return 1 if the number of bits needed is 0. Calculation furtherdown would
     // overflow, and shortcutting here does not leak information because the
@@ -97,14 +96,11 @@ impl PathOramDeterministicEvictor {
     /// Create a new deterministic branch selector that will select
     /// num_elements_to_evict branches per access
     /// tree height: corresponds to the height of tree
-    pub fn new(
-        number_of_additional_branches_to_evict: usize,
-        tree_height: u32,
-    ) -> Self {
+    pub fn new(number_of_additional_branches_to_evict: usize, tree_height: u32) -> Self {
         Self {
             number_of_additional_branches_to_evict,
             tree_height,
-            tree_breadth: 2u64^(tree_height as u64),
+            tree_breadth: 2u64 ^ (tree_height as u64),
             branches_evicted: 0,
         }
     }
@@ -161,13 +157,12 @@ fn path_oram_eviction_strategy<ValueSize, Z>(
 }
 
 pub trait BranchSelector {
-    /// Returns the leaf index of the next branch to call 
+    /// Returns the leaf index of the next branch to call
     /// [EvictionStrategy::evict_from_stash_to_branch] on.
     fn get_next_branch_to_evict(&mut self) -> u64;
 
-    /// Returns the number of branches to call 
+    /// Returns the number of branches to call
     /// [EvictionStrategy::evict_from_stash_to_branch] on.
-
     fn get_number_of_additional_branches_to_evict(&self) -> usize;
 }
 
@@ -201,13 +196,15 @@ where
     type Output: EvictionStrategy<ValueSize, Z> + BranchSelector + Send + Sync + 'static;
 
     /// Creates an eviction strategy
-    /// height: height of the tree eviction will be called on, impacts branch selection.
+    /// height: height of the tree eviction will be called on, impacts branch
+    /// selection.
     fn create(&self, height: u32) -> Self::Output;
 }
 
 /// A factory which creates an PathOramDeterministicEvictor that evicts from the
-/// stash into an additional `number_of_additional_branches_to_evict` branches in
-/// addition to the currently checked out branch in reverse lexicographic order
+/// stash into an additional `number_of_additional_branches_to_evict` branches
+/// in addition to the currently checked out branch in reverse lexicographic
+/// order.
 pub struct PathOramDeterministicEvictorCreator {
     number_of_additional_branches_to_evict: usize,
 }

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -58,26 +58,6 @@ where
     branches_evicted: u64,
     tree_height: u32,
 }
-#[allow(dead_code)]
-impl<RngType> PathOramRandomEvict<RngType>
-where
-    RngType: RngCore + CryptoRng + Send + Sync + 'static,
-{
-    /// Create a new deterministic branch selector that will select
-    /// num_elements_to_evict branches per access
-    pub fn new(
-        number_of_additional_branches_to_evict: usize,
-        tree_height: u32,
-        rng: RngType,
-    ) -> Self {
-        Self {
-            rng,
-            number_of_additional_branches_to_evict,
-            tree_height,
-            branches_evicted: 0,
-        }
-    }
-}
 
 impl<RngType> BranchSelector for PathOramRandomEvict<RngType>
 where

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -33,6 +33,7 @@ mod position_map;
 pub use position_map::{ORAMU32PositionMap, TrivialPositionMap, U32PositionMapCreator};
 
 mod evictor;
+pub use evictor::{PathOramDeterministicEvict, PathOramDeterministicEvictCreator};
 
 mod path_oram;
 pub use path_oram::PathORAM;
@@ -56,14 +57,21 @@ where
     R: RngCore + CryptoRng + Send + Sync + 'static,
     SC: ORAMStorageCreator<U4096, U32>,
 {
-    type Output = PathORAM<U2048, U2, SC::Output, R>;
+    type Output = PathORAM<U2048, U2, SC::Output, R, PathOramDeterministicEvict>;
 
     fn create<M: 'static + FnMut() -> R>(
         size: u64,
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        PathORAM::new::<U32PositionMapCreator<U2048, R, Self>, SC, M>(size, stash_size, rng_maker)
+        let evictor_factory = PathOramDeterministicEvictCreator::new(0);
+
+        PathORAM::new::<
+            U32PositionMapCreator<U2048, R, Self>,
+            SC,
+            M,
+            PathOramDeterministicEvictCreator,
+        >(size, stash_size, rng_maker, evictor_factory)
     }
 }
 
@@ -83,14 +91,21 @@ where
     R: RngCore + CryptoRng + Send + Sync + 'static,
     SC: ORAMStorageCreator<U4096, U64>,
 {
-    type Output = PathORAM<U1024, U4, SC::Output, R>;
+    type Output = PathORAM<U1024, U4, SC::Output, R, PathOramDeterministicEvict>;
 
     fn create<M: 'static + FnMut() -> R>(
         size: u64,
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        PathORAM::new::<U32PositionMapCreator<U1024, R, Self>, SC, M>(size, stash_size, rng_maker)
+        let evictor_factory = PathOramDeterministicEvictCreator::new(0);
+
+        PathORAM::new::<
+            U32PositionMapCreator<U1024, R, Self>,
+            SC,
+            M,
+            PathOramDeterministicEvictCreator,
+        >(size, stash_size, rng_maker, evictor_factory)
     }
 }
 

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -33,7 +33,7 @@ mod position_map;
 pub use position_map::{ORAMU32PositionMap, TrivialPositionMap, U32PositionMapCreator};
 
 mod evictor;
-pub use evictor::{PathOramDeterministicEvict, PathOramDeterministicEvictorCreator};
+pub use evictor::{PathOramDeterministicEvictor, PathOramDeterministicEvictorCreator};
 
 mod path_oram;
 pub use path_oram::PathORAM;
@@ -57,7 +57,7 @@ where
     R: RngCore + CryptoRng + Send + Sync + 'static,
     SC: ORAMStorageCreator<U4096, U32>,
 {
-    type Output = PathORAM<U2048, U2, SC::Output, R, PathOramDeterministicEvict>;
+    type Output = PathORAM<U2048, U2, SC::Output, R, PathOramDeterministicEvictor>;
 
     fn create<M: 'static + FnMut() -> R>(
         size: u64,
@@ -91,7 +91,7 @@ where
     R: RngCore + CryptoRng + Send + Sync + 'static,
     SC: ORAMStorageCreator<U4096, U64>,
 {
-    type Output = PathORAM<U1024, U4, SC::Output, R, PathOramDeterministicEvict>;
+    type Output = PathORAM<U1024, U4, SC::Output, R, PathOramDeterministicEvictor>;
 
     fn create<M: 'static + FnMut() -> R>(
         size: u64,

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -33,7 +33,7 @@ mod position_map;
 pub use position_map::{ORAMU32PositionMap, TrivialPositionMap, U32PositionMapCreator};
 
 mod evictor;
-pub use evictor::{PathOramDeterministicEvict, PathOramDeterministicEvictCreator};
+pub use evictor::{PathOramDeterministicEvict, PathOramDeterministicEvictorCreator};
 
 mod path_oram;
 pub use path_oram::PathORAM;
@@ -64,13 +64,13 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        let evictor_factory = PathOramDeterministicEvictCreator::new(0);
+        let evictor_factory = PathOramDeterministicEvictorCreator::new(0);
 
         PathORAM::new::<
             U32PositionMapCreator<U2048, R, Self>,
             SC,
             M,
-            PathOramDeterministicEvictCreator,
+            PathOramDeterministicEvictorCreator,
         >(size, stash_size, rng_maker, evictor_factory)
     }
 }
@@ -98,13 +98,13 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        let evictor_factory = PathOramDeterministicEvictCreator::new(0);
+        let evictor_factory = PathOramDeterministicEvictorCreator::new(0);
 
         PathORAM::new::<
             U32PositionMapCreator<U1024, R, Self>,
             SC,
             M,
-            PathOramDeterministicEvictCreator,
+            PathOramDeterministicEvictorCreator,
         >(size, stash_size, rng_maker, evictor_factory)
     }
 }

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -64,6 +64,9 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
+        // Number of additional branches to evict is 0 because path oram densely packs
+        // the branch which contains the accessed element, and thus no additional
+        // branches need to be evicted to maintain performance.
         let evictor_factory = PathOramDeterministicEvictorCreator::new(0);
 
         PathORAM::new::<
@@ -98,6 +101,9 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
+        // Number of additional branches to evict is 0 because path oram densely packs
+        // the branch which contains the accessed element, and thus no additional
+        // branches need to be evicted to maintain performance.
         let evictor_factory = PathOramDeterministicEvictorCreator::new(0);
 
         PathORAM::new::<

--- a/mc-oblivious-ram/src/path_oram/mod.rs
+++ b/mc-oblivious-ram/src/path_oram/mod.rs
@@ -15,7 +15,7 @@
 
 use alloc::vec;
 
-use crate::evictor::{Evictor, PathOramEvict};
+use crate::evictor::{BranchSelector, EvictionStrategy, EvictorCreator};
 use aligned_cmov::{
     subtle::{Choice, ConstantTimeEq, ConstantTimeLess},
     typenum::{PartialDiv, Prod, Unsigned, U16, U64, U8},
@@ -83,12 +83,13 @@ fn meta_set_vacant(condition: Choice, src: &mut A8Bytes<MetaSize>) {
 }
 
 /// An implementation of PathORAM, using u64 to represent leaves in metadata.
-pub struct PathORAM<ValueSize, Z, StorageType, RngType>
+pub struct PathORAM<ValueSize, Z, StorageType, RngType, EvictorType>
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
     RngType: RngCore + CryptoRng + Send + Sync + 'static,
     StorageType: ORAMStorage<Prod<Z, ValueSize>, Prod<Z, MetaSize>> + Send + Sync + 'static,
+    EvictorType: EvictionStrategy<ValueSize, Z> + BranchSelector + Send + Sync + 'static,
     Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
     Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
 {
@@ -107,15 +108,17 @@ where
     /// Our currently checked-out branch if any
     branch: BranchCheckout<ValueSize, Z>,
     /// Eviction strategy
-    evictor: Box<dyn Evictor<ValueSize, Z> + Send + Sync + 'static>,
+    evictor: EvictorType,
 }
 
-impl<ValueSize, Z, StorageType, RngType> PathORAM<ValueSize, Z, StorageType, RngType>
+impl<ValueSize, Z, StorageType, RngType, EvictorType>
+    PathORAM<ValueSize, Z, StorageType, RngType, EvictorType>
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
     RngType: RngCore + CryptoRng + Send + Sync + 'static,
     StorageType: ORAMStorage<Prod<Z, ValueSize>, Prod<Z, MetaSize>> + Send + Sync + 'static,
+    EvictorType: EvictionStrategy<ValueSize, Z> + BranchSelector + Send + Sync + 'static,
     Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
     Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
 {
@@ -129,10 +132,12 @@ where
         PMC: PositionMapCreator<RngType>,
         SC: ORAMStorageCreator<Prod<Z, ValueSize>, Prod<Z, MetaSize>, Output = StorageType>,
         F: FnMut() -> RngType + 'static,
+        EVC: EvictorCreator<ValueSize, Z, Output = EvictorType>,
     >(
         size: u64,
         stash_size: usize,
         rng_maker: &mut F,
+        evictor_factory: EVC,
     ) -> Self {
         assert!(size != 0, "size cannot be zero");
         assert!(size & (size - 1) == 0, "size must be a power of two");
@@ -142,9 +147,9 @@ where
         // the height of the root to be 0, so in a tree where the lowest level
         // is h, there are 2^{h+1} nodes.
         let mut rng = rng_maker();
+        let evictor = evictor_factory.create(size, height);
         let storage = SC::create(2u64 << height, &mut rng).expect("Storage failed");
         let pos = PMC::create(size, height, stash_size, rng_maker);
-        let evictor = Box::new(PathOramEvict::new());
         Self {
             height,
             storage,
@@ -158,13 +163,14 @@ where
     }
 }
 
-impl<ValueSize, Z, StorageType, RngType> ORAM<ValueSize>
-    for PathORAM<ValueSize, Z, StorageType, RngType>
+impl<ValueSize, Z, StorageType, RngType, EvictorType> ORAM<ValueSize>
+    for PathORAM<ValueSize, Z, StorageType, RngType, EvictorType>
 where
     ValueSize: ArrayLength<u8> + PartialDiv<U8> + PartialDiv<U64>,
     Z: Unsigned + Mul<ValueSize> + Mul<MetaSize>,
     RngType: RngCore + CryptoRng + Send + Sync + 'static,
     StorageType: ORAMStorage<Prod<Z, ValueSize>, Prod<Z, MetaSize>> + Send + Sync + 'static,
+    EvictorType: EvictionStrategy<ValueSize, Z> + BranchSelector + Send + Sync + 'static,
     Prod<Z, ValueSize>: ArrayLength<u8> + PartialDiv<U8>,
     Prod<Z, MetaSize>: ArrayLength<u8> + PartialDiv<U8>,
 {
@@ -250,6 +256,19 @@ where
         debug_assert!(self.branch.leaf == current_pos);
         self.branch.checkin(&mut self.storage);
         debug_assert!(self.branch.leaf == 0);
+
+        for _ in 0..self.evictor.get_number_of_additional_branches_to_evict() {
+            let leaf = self.evictor.get_next_branch_to_evict();
+            debug_assert!(leaf != 0);
+            self.branch.checkout(&mut self.storage, leaf);
+            self.evictor.evict_from_stash_to_branch(
+                &mut self.stash_data,
+                &mut self.stash_meta,
+                &mut self.branch,
+            );
+            self.branch.checkin(&mut self.storage);
+            debug_assert!(self.branch.leaf == 0);
+        }
 
         result
     }

--- a/mc-oblivious-ram/src/path_oram/mod.rs
+++ b/mc-oblivious-ram/src/path_oram/mod.rs
@@ -147,7 +147,7 @@ where
         // the height of the root to be 0, so in a tree where the lowest level
         // is h, there are 2^{h+1} nodes.
         let mut rng = rng_maker();
-        let evictor = evictor_factory.create(size, height);
+        let evictor = evictor_factory.create(height);
         let storage = SC::create(2u64 << height, &mut rng).expect("Storage failed");
         let pos = PMC::create(size, height, stash_size, rng_maker);
         Self {

--- a/no-asm-tests/Cargo.lock
+++ b/no-asm-tests/Cargo.lock
@@ -93,6 +93,8 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 name = "test-helper"
 version = "2.0.0"
 dependencies = [
+ "aligned-array",
+ "aligned-cmov",
  "rand_core",
  "rand_hc",
 ]

--- a/no-asm-tests/src/main.rs
+++ b/no-asm-tests/src/main.rs
@@ -5,7 +5,7 @@ use aligned_cmov::{
     ArrayLength,
 };
 use core::marker::PhantomData;
-use mc_oblivious_ram::PathORAM;
+use mc_oblivious_ram::{PathORAM, PathOramDeterministicEvict, PathOramDeterministicEvictCreator};
 use mc_oblivious_traits::{
     rng_maker, HeapORAMStorageCreator, ORAMCreator, ORAMStorageCreator, ORAM,
 };
@@ -48,7 +48,7 @@ where
         }
     }
 
-    return None;
+    None
 }
 
 pub fn main() {
@@ -103,14 +103,20 @@ pub struct InsecurePathORAM4096Z4Creator<SC: ORAMStorageCreator<U4096, U64>> {
 impl<SC: ORAMStorageCreator<U4096, U64>> ORAMCreator<U1024, RngType>
     for InsecurePathORAM4096Z4Creator<SC>
 {
-    type Output = PathORAM<U1024, U4, SC::Output, RngType>;
+    type Output = PathORAM<U1024, U4, SC::Output, RngType, PathOramDeterministicEvict>;
 
     fn create<M: 'static + FnMut() -> RngType>(
         size: u64,
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        PathORAM::new::<InsecurePositionMapCreator<RngType>, SC, M>(size, stash_size, rng_maker)
+        let evictor_factory = PathOramDeterministicEvictCreator::new(0);
+        PathORAM::new::<InsecurePositionMapCreator<RngType>, SC, M, PathOramDeterministicEvictCreator>(
+            size,
+            stash_size,
+            rng_maker,
+            evictor_factory,
+        )
     }
 }
 
@@ -121,7 +127,7 @@ mod tests {
     use core::convert::TryInto;
     use mc_oblivious_traits::{rng_maker, testing, HeapORAMStorageCreator, ORAMCreator};
     use std::vec;
-    use test_helper::{run_with_several_seeds, run_with_one_seed};
+    use test_helper::{run_with_one_seed, run_with_several_seeds};
 
     // Run the exercise oram tests for 200,000 rounds in 131072 sized z4 oram
     #[test]
@@ -211,7 +217,8 @@ mod tests {
         const VARIANCE_THRESHOLD: f64 = 0.15;
 
         run_with_one_seed(|rng| {
-            let mut oram_size_to_stash_size_by_count = BTreeMap::<u32, BTreeMap<usize, usize>>::default();
+            let mut oram_size_to_stash_size_by_count =
+                BTreeMap::<u32, BTreeMap<usize, usize>>::default();
             let mut maker = rng_maker(rng);
             for oram_power in (10..24).step_by(2) {
                 let mut rng = maker();
@@ -229,7 +236,7 @@ mod tests {
             }
             for stash_num in 1..6 {
                 let mut probability_of_stash_size = vec::Vec::new();
-                for (_oram_power, stash_size_by_count) in &oram_size_to_stash_size_by_count { 
+                for (_oram_power, stash_size_by_count) in &oram_size_to_stash_size_by_count {
                     if let Some(stash_count) = stash_size_by_count.get(&stash_num) {
                         let stash_count_probability =
                             (NUM_ROUNDS as f64 / *stash_count as f64).log2();

--- a/test-helper/Cargo.toml
+++ b/test-helper/Cargo.toml
@@ -5,5 +5,7 @@ authors = ["Chris Beck <beck.ct@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+aligned-array = { version = "1", features = ["subtle"] }
+aligned-cmov = { path = "../aligned-cmov", version = "2.2" }
 rand_core = { version = "0.6", default-features = false }
 rand_hc = "0.3"

--- a/test-helper/src/lib.rs
+++ b/test-helper/src/lib.rs
@@ -1,3 +1,4 @@
+use aligned_cmov::{A8Bytes, ArrayLength};
 pub use rand_core::{CryptoRng, RngCore, SeedableRng};
 use rand_hc::Hc128Rng;
 type Seed = <RngType as SeedableRng>::Seed;
@@ -32,4 +33,14 @@ fn get_seeds() -> [Seed; NUM_TRIALS] {
 
 pub fn get_seeded_rng() -> RngType {
     RngType::from_seed([7u8; 32])
+}
+
+/// Make a8-bytes that are initialized to a particular byte value
+/// This makes tests shorter to write
+pub fn a8_8<N: ArrayLength<u8>>(src: u8) -> A8Bytes<N> {
+    let mut result = A8Bytes::<N>::default();
+    for byte in result.as_mut_slice() {
+        *byte = src;
+    }
+    result
 }


### PR DESCRIPTION
The motivation for this PR is to let Path_oram use multiple different kinds of evictors. 

This PR: 

- Refactors path_oram to take in an evictor factory, and adds 2 kinds of path oram evictor using different branch selection strategies. The functionality in this case should be the same as preexisting code, because the evictors created do not evict any additional branches and only pack the stash into the already checked out branch, as in the current code. 
- Updates associated Oram_creators in path_oram/lib.rs and no_asm crate. 
- Adds a function that iterates over branches reverse lexicographically and associated tests

This PR is part of the following PR chain
- https://github.com/mobilecoinfoundation/mc-oblivious/pull/36
- https://github.com/wjuan-mob/mc-oblivious/pull/7
- https://github.com/wjuan-mob/mc-oblivious/pull/8
- https://github.com/wjuan-mob/mc-oblivious/pull/9