### PR TITLE
Circuit oram/add oblivious circuit oram

### DIFF
--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -3,7 +3,6 @@
 //! These are intended to be a module containing different eviction strategies
 //! for tree based orams which include path oram and circuit oram. These
 //! strategies will be used for evicting stash elements to the tree oram.
-#![allow(dead_code)]
 use aligned_cmov::A8Bytes;
 
 use aligned_cmov::A64Bytes;

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -561,11 +561,11 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
         let bucket_data: &mut [A64Bytes<ValueSize>] = upper_data[0].as_mut_aligned_chunks();
         let bucket_meta: &mut [A8Bytes<MetaSize>] = upper_meta[0].as_mut_aligned_chunks();
 
-        let mut dummy_to_write_data: A64Bytes<ValueSize> = Default::default();
-        let mut dummy_to_write_meta: A8Bytes<MetaSize> = Default::default();
-
-        let to_write_data: &mut A64Bytes<ValueSize> = &mut dummy_to_write_data;
-        let to_write_meta: &mut A8Bytes<MetaSize> = &mut dummy_to_write_meta;
+        // This to_write dummy are being used as a temporary space to be used
+        // for a 3 way swap to move the held item into the bucket that is full,
+        // and pick up an element from the bucket at the same time.
+        let mut temp_to_write_data: A64Bytes<ValueSize> = Default::default();
+        let mut temp_to_write_meta: A8Bytes<MetaSize> = Default::default();
 
         //If held element is not vacant and bucket_num is dest. We will write this elem
         // so zero out the held/dest.
@@ -574,8 +574,8 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
             held_data,
             bucket_num,
             &mut dest,
-            to_write_meta,
-            to_write_data,
+            &mut temp_to_write_meta,
+            &mut temp_to_write_data,
         );
         debug_assert!(bucket_data.len() == bucket_meta.len());
         let (_deepest_target, id_of_the_deepest_target_for_level) =
@@ -597,8 +597,8 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
 
         ct_insert(
             held_elem_is_not_vacant_and_bucket_num_is_at_dest,
-            to_write_data,
-            to_write_meta,
+            &mut temp_to_write_data,
+            &mut temp_to_write_meta,
             bucket_data,
             bucket_meta,
         );

--- a/mc-oblivious-ram/src/evictor/mod.rs
+++ b/mc-oblivious-ram/src/evictor/mod.rs
@@ -539,7 +539,7 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
     // putting it in the hold and setting dest to the target[STASH_INDEX]
     let (_deepest_target, id_of_the_deepest_target_for_level) =
         find_index_of_deepest_target_for_bucket::<ValueSize, Z>(stash_meta, branch.leaf, meta_len);
-    update_dest_and_take_an_item_to_hold_if_appropriate(
+    compare_and_take_held_item_if_appropriate(
         stash_index,
         &target_meta,
         stash_meta,
@@ -569,7 +569,7 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
 
         //If held element is not vacant and bucket_num is dest. We will write this elem
         // so zero out the held/dest.
-        let held_elem_is_not_vacant_and_bucket_num_is_at_dest = swap_held_element_if_at_destination(
+        let held_elem_is_not_vacant_and_bucket_num_is_at_dest = drop_held_element_if_at_destination(
             held_meta,
             held_data,
             bucket_num,
@@ -584,7 +584,7 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
                 branch.leaf,
                 meta_len,
             );
-        update_dest_and_take_an_item_to_hold_if_appropriate(
+        compare_and_take_held_item_if_appropriate(
             bucket_num,
             &target_meta,
             bucket_meta,
@@ -603,7 +603,7 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
             bucket_meta,
         );
     }
-    fn update_dest_and_take_an_item_to_hold_if_appropriate<ValueSize>(
+    fn compare_and_take_held_item_if_appropriate<ValueSize>(
         bucket_index: usize,
         target_meta: &[usize],
         bucket_meta: &mut [A8Bytes<MetaSize>],
@@ -632,7 +632,7 @@ fn circuit_oram_eviction_strategy<ValueSize, Z>(
         );
     }
 
-    fn swap_held_element_if_at_destination<ValueSize>(
+    fn drop_held_element_if_at_destination<ValueSize>(
         held_meta: &mut A8Bytes<MetaSize>,
         held_data: &mut A64Bytes<ValueSize>,
         bucket_num: usize,

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -41,6 +41,13 @@ pub use evictor::{
 mod path_oram;
 pub use path_oram::PathORAM;
 
+/// For circuit oram to have linear stash size growth at least 2 additional
+/// branches that are sufficiently non overlapping must be evicted every time.
+/// This constant is passed into the evictor creator to specify the number of
+/// additional branches to evict per eviction
+const ADDITIONAL_BRANCHES_TO_EVICT: usize = 2;
+
+
 /// Creator for PathORAM based on 4096-sized blocks of storage and bucket size
 /// (Z) of 2, and a basic recursive position map implementation
 ///
@@ -101,6 +108,9 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
+        // Path Oram's evict creator does not need to evict more branches than
+        // the checked out branch due to packing the stash densely, therefore
+        // passing 0 additional branches to evict.
         let evictor_factory = PathOramDeterministicEvictCreator::new(0);
 
         PathORAM::new::<
@@ -135,7 +145,7 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        let evictor_factory = CircuitOramDeterministicEvictCreator::new(2);
+        let evictor_factory = CircuitOramDeterministicEvictCreator::new(ADDITIONAL_BRANCHES_TO_EVICT);
         PathORAM::new::<
             U32PositionMapCreator<U1024, R, Self>,
             SC,
@@ -168,7 +178,7 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        let evictor_factory = CircuitOramDeterministicEvictCreator::new(2);
+        let evictor_factory = CircuitOramDeterministicEvictCreator::new(ADDITIONAL_BRANCHES_TO_EVICT);
         PathORAM::new::<
             U32PositionMapCreator<U2048, R, Self>,
             SC,

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -135,7 +135,7 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        let evictor_factory = CircuitOramDeterministicEvictCreator::new(0);
+        let evictor_factory = CircuitOramDeterministicEvictCreator::new(2);
         PathORAM::new::<
             U32PositionMapCreator<U1024, R, Self>,
             SC,
@@ -168,7 +168,7 @@ where
         stash_size: usize,
         rng_maker: &mut M,
     ) -> Self::Output {
-        let evictor_factory = CircuitOramDeterministicEvictCreator::new(0);
+        let evictor_factory = CircuitOramDeterministicEvictCreator::new(2);
         PathORAM::new::<
             U32PositionMapCreator<U2048, R, Self>,
             SC,
@@ -402,6 +402,110 @@ mod testing {
             assert_eq!(a64_bytes(8), oram.write(9, &a64_bytes(12)));
             assert_eq!(a64_bytes(12), oram.read(9));
         })
+    }
+
+    // Sanity check the z4 circuit oram
+    #[test]
+    fn sanity_check_circuit_oram_z4_262144() {
+        run_with_several_seeds(|rng| {
+            let mut oram = CircuitORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                262144,
+                STASH_SIZE,
+                &mut rng_maker(rng),
+            );
+            assert_eq!(a64_bytes(0), oram.write(0, &a64_bytes(1)));
+            assert_eq!(a64_bytes(1), oram.write(0, &a64_bytes(2)));
+            assert_eq!(a64_bytes(2), oram.write(0, &a64_bytes(3)));
+            assert_eq!(a64_bytes(0), oram.write(2, &a64_bytes(4)));
+            assert_eq!(a64_bytes(4), oram.write(2, &a64_bytes(5)));
+            assert_eq!(a64_bytes(3), oram.write(0, &a64_bytes(6)));
+            assert_eq!(a64_bytes(6), oram.write(0, &a64_bytes(7)));
+            assert_eq!(a64_bytes(0), oram.write(9, &a64_bytes(8)));
+            assert_eq!(a64_bytes(5), oram.write(2, &a64_bytes(10)));
+            assert_eq!(a64_bytes(7), oram.write(0, &a64_bytes(11)));
+            assert_eq!(a64_bytes(8), oram.write(9, &a64_bytes(12)));
+            assert_eq!(a64_bytes(12), oram.read(9));
+        })
+    }
+
+    // Run the exercise oram tests for 20,000 rounds in 8192 sized z4 oram circuit
+    // oram
+    #[test]
+    fn exercise_circuit_oram_z4_8192() {
+        run_with_several_seeds(|rng| {
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = CircuitORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                8192, STASH_SIZE, &mut maker,
+            );
+            testing::exercise_oram(20_000, &mut oram, &mut rng);
+        });
+    }
+
+    // Run the exercise oram tests for 20,000 rounds in 8192 sized z4 oram circuit
+    // oram
+    #[test]
+    fn exercise_consecutive_circuit_oram_z4_8192() {
+        run_with_several_seeds(|rng| {
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = CircuitORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                8192, STASH_SIZE, &mut maker,
+            );
+            testing::exercise_oram_consecutive(20_000, &mut oram, &mut rng);
+        });
+    }
+
+    // Sanity check the z4 circuit oram
+    #[test]
+    fn sanity_check_circuit_oram_z2_262144() {
+        run_with_several_seeds(|rng| {
+            let mut oram = CircuitORAM4096Z2Creator::<RngType, HeapORAMStorageCreator>::create(
+                262144,
+                STASH_SIZE,
+                &mut rng_maker(rng),
+            );
+            assert_eq!(a64_bytes(0), oram.write(0, &a64_bytes(1)));
+            assert_eq!(a64_bytes(1), oram.write(0, &a64_bytes(2)));
+            assert_eq!(a64_bytes(2), oram.write(0, &a64_bytes(3)));
+            assert_eq!(a64_bytes(0), oram.write(2, &a64_bytes(4)));
+            assert_eq!(a64_bytes(4), oram.write(2, &a64_bytes(5)));
+            assert_eq!(a64_bytes(3), oram.write(0, &a64_bytes(6)));
+            assert_eq!(a64_bytes(6), oram.write(0, &a64_bytes(7)));
+            assert_eq!(a64_bytes(0), oram.write(9, &a64_bytes(8)));
+            assert_eq!(a64_bytes(5), oram.write(2, &a64_bytes(10)));
+            assert_eq!(a64_bytes(7), oram.write(0, &a64_bytes(11)));
+            assert_eq!(a64_bytes(8), oram.write(9, &a64_bytes(12)));
+            assert_eq!(a64_bytes(12), oram.read(9));
+        })
+    }
+
+    // Run the exercise oram tests for 20,000 rounds in 8192 sized z4 oram circuit
+    // oram
+    #[test]
+    fn exercise_circuit_oram_z2_8192() {
+        run_with_several_seeds(|rng| {
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = CircuitORAM4096Z2Creator::<RngType, HeapORAMStorageCreator>::create(
+                8192, STASH_SIZE, &mut maker,
+            );
+            testing::exercise_oram(20_000, &mut oram, &mut rng);
+        });
+    }
+
+    // Run the exercise oram tests for 20,000 rounds in 8192 sized z4 oram circuit
+    // oram
+    #[test]
+    fn exercise_consecutive_circuit_oram_z2_8192() {
+        run_with_several_seeds(|rng| {
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = CircuitORAM4096Z2Creator::<RngType, HeapORAMStorageCreator>::create(
+                8192, STASH_SIZE, &mut maker,
+            );
+            testing::exercise_oram_consecutive(20_000, &mut oram, &mut rng);
+        });
     }
 
     // Run the exercise oram tests for 20,000 rounds in 8192 sized z4 oram

--- a/no-asm-tests/src/main.rs
+++ b/no-asm-tests/src/main.rs
@@ -1,11 +1,14 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 use aligned_cmov::{
-    typenum::{U1024, U4, U4096, U64},
+    typenum::{U1024, U2, U2048, U32, U4, U4096, U64},
     ArrayLength,
 };
 use core::marker::PhantomData;
-use mc_oblivious_ram::{PathORAM, PathOramDeterministicEvict, PathOramDeterministicEvictCreator};
+use mc_oblivious_ram::{
+    CircuitOramDeterministicEvict, CircuitOramDeterministicEvictCreator, PathORAM,
+    PathOramDeterministicEvict, PathOramDeterministicEvictCreator,
+};
 use mc_oblivious_traits::{
     rng_maker, HeapORAMStorageCreator, ORAMCreator, ORAMStorageCreator, ORAM,
 };
@@ -112,6 +115,40 @@ impl<SC: ORAMStorageCreator<U4096, U64>> ORAMCreator<U1024, RngType>
     ) -> Self::Output {
         let evictor_factory = PathOramDeterministicEvictCreator::new(0);
         PathORAM::new::<InsecurePositionMapCreator<RngType>, SC, M, PathOramDeterministicEvictCreator>(
+            size,
+            stash_size,
+            rng_maker,
+            evictor_factory,
+        )
+    }
+}
+
+/// Creator for CircuitOram based on 4096-sized blocks of storage
+/// and bucket size (Z) of 2, and the insecure position map implementation.
+/// This is used to determine calibrate circuit oram
+pub struct InsecureCircuitORAM4096Z2Creator<R, SC: ORAMStorageCreator<U4096, U32>>
+where
+    R: RngCore + CryptoRng + 'static,
+{
+    _sc: PhantomData<fn() -> SC>,
+    _rng: PhantomData<fn() -> R>,
+}
+
+impl<R, SC: ORAMStorageCreator<U4096, U32>> ORAMCreator<U2048, R>
+    for InsecureCircuitORAM4096Z2Creator<R, SC>
+where
+    R: RngCore + CryptoRng + Send + Sync + 'static,
+    SC: ORAMStorageCreator<U4096, U32>,
+{
+    type Output = PathORAM<U2048, U2, SC::Output, R, CircuitOramDeterministicEvict>;
+
+    fn create<M: 'static + FnMut() -> R>(
+        size: u64,
+        stash_size: usize,
+        rng_maker: &mut M,
+    ) -> Self::Output {
+        let evictor_factory = CircuitOramDeterministicEvictCreator::new(2);
+        PathORAM::new::<InsecurePositionMapCreator<R>, SC, M, CircuitOramDeterministicEvictCreator>(
             size,
             stash_size,
             rng_maker,
@@ -258,6 +295,58 @@ mod tests {
                 #[cfg(debug_assertions)]
                 dbg!(stash_num, data_variance);
                 assert!(data_variance < VARIANCE_THRESHOLD);
+            }
+        });
+    }
+
+    // Run the analysis oram tests similar to CircuitOram section 5. Warm up with
+    // 2^10 accesses, then run for 2^20 accesses cycling through all N logical
+    // addresses. N=2^10. This choice is arbitrary because stash size should not
+    // depend on N. Measure the number of times that the stash is above any
+    // given size.
+    #[test]
+    fn analyse_obliviouscircuit_oram_z2_8192() {
+        const STASH_SIZE: usize = 32;
+        const CORRELATION_THRESHOLD: f64 = 0.85;
+        run_with_several_seeds(|rng| {
+            let base: u64 = 2;
+            let num_prerounds: u64 = base.pow(10);
+            let num_rounds: u64 = base.pow(10);
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram =
+                InsecureCircuitORAM4096Z2Creator::<RngType, HeapORAMStorageCreator>::create(
+                    base.pow(10),
+                    STASH_SIZE,
+                    &mut maker,
+                );
+            let stash_stats = testing::measure_oram_stash_size_distribution(
+                num_prerounds.try_into().unwrap(),
+                num_rounds.try_into().unwrap(),
+                &mut oram,
+                &mut rng,
+            );
+            let mut x_axis: vec::Vec<f64> = vec::Vec::new();
+            let mut y_axis: vec::Vec<f64> = vec::Vec::new();
+            #[cfg(debug_assertions)]
+            dbg!(stash_stats.get(&0).unwrap_or(&0));
+            for stash_count in 1..STASH_SIZE {
+                if let Some(stash_count_probability) = stash_stats.get(&stash_count) {
+                    #[cfg(debug_assertions)]
+                    dbg!(stash_count, stash_count_probability);
+                    y_axis.push((num_rounds as f64 / *stash_count_probability as f64).log2());
+                    x_axis.push(stash_count as f64);
+                } else {
+                    #[cfg(debug_assertions)]
+                    dbg!(stash_count);
+                }
+            }
+            if x_axis.len() > 5 {
+                let correlation =
+                    rgsl::statistics::correlation(&x_axis, 1, &y_axis, 1, x_axis.len());
+                #[cfg(debug_assertions)]
+                dbg!(correlation);
+                assert!(correlation > CORRELATION_THRESHOLD);
             }
         });
     }


### PR DESCRIPTION
The motivation for this PR is to add the Circuit Oram Creators and circuit oram evictor to be used by omaps and other actual implementations.

This PR:

- Adds a circuit oram evict creator
- Adds circuit oram z4 and z2 creators
- Adds sanity and exercise tests for the z4 and z2 creators
- Adds no asm analysis test for z2 creator.

This is part of the PR chain

1. https://github.com/mobilecoinfoundation/mc-oblivious/pull/36
2. https://github.com/wjuan-mob/mc-oblivious/pull/7
3. https://github.com/wjuan-mob/mc-oblivious/pull/8
4. https://github.com/wjuan-mob/mc-oblivious/pull/9